### PR TITLE
Dropped zk scheme for zk_hosts param

### DIFF
--- a/mesos/chronos/README.md
+++ b/mesos/chronos/README.md
@@ -16,7 +16,7 @@ Installed from [Mesosphere](https://mesosphere.com)
 
 ### running from command line
 ```
-docker run -d tomaskral/chronos  --master zk://zoo1:2181,zoo2:2181,zoo3:2181/mesos --zk_hosts zk://zoo1:2181,zoo2:2181,zoo3:2181
+docker run -d tomaskral/chronos  --master zk://zoo1:2181,zoo2:2181,zoo3:2181/mesos --zk_hosts zoo1:2181,zoo2:2181,zoo3:2181
 ```
 
 ### running on Marathon
@@ -27,7 +27,7 @@ docker run -d tomaskral/chronos  --master zk://zoo1:2181,zoo2:2181,zoo3:2181/mes
     "cpus": 0.1,
     "mem": 512,
     "shell": "false",
-    "args": ["--master", "zk://zoo1:2181,zoo2:2181,zoo3:2181/mesos", "--zk_hosts", "zk://zoo1:2181,zoo2:2181,zoo3:2181"],
+    "args": ["--master", "zk://zoo1:2181,zoo2:2181,zoo3:2181/mesos", "--zk_hosts", "zoo1:2181,zoo2:2181,zoo3:2181"],
     "container": {
         "type": "DOCKER",
         "docker": {


### PR DESCRIPTION
zk_hosts parameter should not be using zk scheme per Chronos docs
